### PR TITLE
Add -Wno-unused-parameter in case warning_level would include it

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,9 @@
 project('chipmunk', 'c', version : '6.2.2', license : 'MIT')
 
 cc = meson.get_compiler('c')
+add_project_arguments(cc.get_supported_arguments([
+	'-Wno-unused-parameter',
+]), language : 'c')
 m_dep = cc.find_library('m', required : false)
 
 inc = include_directories('include/chipmunk')


### PR DESCRIPTION
Chipmunk2d is full of unused parameters:

```
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c: In Funktion »BBToBounds«:
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c:53:23: Warnung: unverwendeter Parameter »sweep« [-Wunused-parameter]
   53 | BBToBounds(cpSweep1D *sweep, cpBB bb)
      |            ~~~~~~~~~~~^~~~~
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c: In Funktion »cpSweep1DContains«:
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c:121:60: Warnung: unverwendeter Parameter »hashid« [-Wunused-parameter]
  121 | cpSweep1DContains(cpSweep1D *sweep, void *obj, cpHashValue hashid)
      |                                                ~~~~~~~~~~~~^~~~~~
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c: In Funktion »cpSweep1DInsert«:
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c:134:58: Warnung: unverwendeter Parameter »hashid« [-Wunused-parameter]
  134 | cpSweep1DInsert(cpSweep1D *sweep, void *obj, cpHashValue hashid)
      |                                              ~~~~~~~~~~~~^~~~~~
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c: In Funktion »cpSweep1DRemove«:
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c:143:58: Warnung: unverwendeter Parameter »hashid« [-Wunused-parameter]
  143 | cpSweep1DRemove(cpSweep1D *sweep, void *obj, cpHashValue hashid)
      |                                              ~~~~~~~~~~~~^~~~~~
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c: In Funktion »cpSweep1DReindexObject«:
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c:161:35: Warnung: unverwendeter Parameter »sweep« [-Wunused-parameter]
  161 | cpSweep1DReindexObject(cpSweep1D *sweep, void *obj, cpHashValue hashid)
      |                        ~~~~~~~~~~~^~~~~
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c:161:48: Warnung: unverwendeter Parameter »obj« [-Wunused-parameter]
  161 | cpSweep1DReindexObject(cpSweep1D *sweep, void *obj, cpHashValue hashid)
      |                                          ~~~~~~^~~
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c:161:65: Warnung: unverwendeter Parameter »hashid« [-Wunused-parameter]
  161 | cpSweep1DReindexObject(cpSweep1D *sweep, void *obj, cpHashValue hashid)
      |                                                     ~~~~~~~~~~~~^~~~~~
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c: In Funktion »cpSweep1DReindex«:
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c:167:29: Warnung: unverwendeter Parameter »sweep« [-Wunused-parameter]
  167 | cpSweep1DReindex(cpSweep1D *sweep)
      |                  ~~~~~~~~~~~^~~~~
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c: In Funktion »cpSweep1DSegmentQuery«:
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/cpSweep1D.c:191:80: Warnung: unverwendeter Parameter »t_exit« [-Wunused-parameter]
  191 | cpSweep1DSegmentQuery(cpSweep1D *sweep, void *obj, cpVect a, cpVect b, cpFloat t_exit, cpSpatialIndexSegmentQueryFunc func, void *data)
      |                                                                        ~~~~~~~~^~~~~~
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/constraints/cpSimpleMotor.c: In Funktion »preStep«:
../subprojects/Chipmunk2D-Chipmunk-6.2.2/src/constraints/cpSimpleMotor.c:26:39: Warnung: unverwendeter Parameter »dt« [-Wunused-parameter]
   26 | preStep(cpSimpleMotor *joint, cpFloat dt)
      |
```